### PR TITLE
Fix rating input handling

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import './App.css'
 import Navbar from './components/Navbar';
 import Home from './pages/Home'

--- a/client/src/components/BooksSearch.tsx
+++ b/client/src/components/BooksSearch.tsx
@@ -26,7 +26,15 @@ const BookSearch = () => {
         `https://www.googleapis.com/books/v1/volumes?q=${encodeURIComponent(query)}`
       );
       const data = await response.json();
-      const books = data.items.map((item: any) => ({
+      interface GoogleItem {
+        id: string;
+        volumeInfo: {
+          title: string;
+          authors?: string[];
+          imageLinks?: { thumbnail?: string };
+        };
+      }
+      const books = data.items.map((item: GoogleItem) => ({
         id: item.id,
         title: item.volumeInfo.title,
         authors: item.volumeInfo.authors || ['Unknown Author'],
@@ -48,7 +56,7 @@ const BookSearch = () => {
       thumbnail: book.thumbnail,
       startDate,
       endDate,
-      rating,
+      rating: rating === '' ? undefined : rating,
       review,
     };
 
@@ -119,7 +127,10 @@ const BookSearch = () => {
                             min="1"
                             max="5"
                             value={rating}
-                            onChange={(e) => setRating(parseInt(e.target.value))}
+                            onChange={(e) => {
+                                const value = e.target.value;
+                                setRating(value === '' ? '' : parseInt(value));
+                            }}
                         />
                     </label>
                     <label>

--- a/client/src/pages/MyBooks.tsx
+++ b/client/src/pages/MyBooks.tsx
@@ -44,7 +44,7 @@ const MyBooks = () => {
     try {
       const updated = {
         ...book,
-        rating: editRating,
+        rating: editRating === '' ? undefined : editRating,
         review: editReview,
       };
 
@@ -112,7 +112,10 @@ const MyBooks = () => {
                         min="1"
                         max="5"
                         value={editRating}
-                        onChange={(e) => setEditRating(Number(e.target.value))}
+                        onChange={(e) => {
+                        const value = e.target.value;
+                        setEditRating(value === '' ? '' : parseInt(value));
+                        }}
                     />
                     </label>
                     <label>


### PR DESCRIPTION
## Summary
- remove unused `useState` in `App.tsx`
- type Google Books items to avoid `any`
- treat empty rating input as empty string
- convert empty rating to `undefined` before sending to API

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685542d8053c83298c8ef31a6f9354e4