### PR TITLE
Add validation and error handling for UserBook API

### DIFF
--- a/server/models/UserBook.js
+++ b/server/models/UserBook.js
@@ -1,13 +1,26 @@
 import mongoose from 'mongoose';
 
 const UserBookSchema = new mongoose.Schema({
-  googleId: String,
-  title: String,
-  authors: [String],
+  googleId: {
+    type: String,
+    required: true,
+  },
+  title: {
+    type: String,
+    required: true,
+  },
+  authors: {
+    type: [String],
+    required: true,
+  },
   thumbnail: String,
   startDate: Date,
   endDate: Date,
-  rating: Number,
+  rating: {
+    type: Number,
+    min: 1,
+    max: 5,
+  },
   review: String,
 });
 

--- a/server/routes/books.js
+++ b/server/routes/books.js
@@ -9,7 +9,11 @@ router.post('/', async (req, res) => {
     await newBook.save();
     res.status(201).json(newBook);
   } catch (err) {
-    res.status(500).json({ error: 'Failed to save book' });
+    if (err.name === 'ValidationError') {
+      res.status(400).json({ error: err.message });
+    } else {
+      res.status(500).json({ error: 'Failed to save book' });
+    }
   }
 });
 
@@ -38,11 +42,15 @@ router.put('/:id', async (req, res) => {
     const updatedBook = await UserBook.findByIdAndUpdate(
       req.params.id,
       req.body,
-      { new: true }
+      { new: true, runValidators: true }
     );
     res.json(updatedBook);
   } catch (err) {
-    res.status(500).json({ error: 'Failed to update book' });
+    if (err.name === 'ValidationError') {
+      res.status(400).json({ error: err.message });
+    } else {
+      res.status(500).json({ error: 'Failed to update book' });
+    }
   }
 });
 


### PR DESCRIPTION
## Summary
- require `googleId`, `title`, and `authors` in the `UserBook` schema
- constrain `rating` between 1 and 5
- handle validation errors in POST and PUT book routes
- run validations when updating books

## Testing
- `npm test` *(fails: Missing script)*
- `cd server && npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68554300fa308329a2441d156f6030e2