### PR TITLE
Return JWT token on signup

### DIFF
--- a/client/src/pages/Signup.tsx
+++ b/client/src/pages/Signup.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
 import './Signup.css';
 
 const Signup = () => {
@@ -7,6 +8,7 @@ const Signup = () => {
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const navigate = useNavigate();
+  const { login } = useAuth();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -25,8 +27,7 @@ const Signup = () => {
       const data = await res.json();
       if (!res.ok) throw new Error(data.message);
 
-      localStorage.setItem('token', data.token);
-      localStorage.setItem('userId', data.userId);
+      login(data.userId, email, data.token);
       navigate('/books');
     } catch (err: any) {
       setError(err.message);

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -16,7 +16,9 @@ router.post('/signup', async (req, res) => {
     const hashedPassword = await bcrypt.hash(password, 10);
     const user = await User.create({ email, password: hashedPassword });
 
-    res.status(201).json({ message: 'User signed up successfully' });
+    const token = jwt.sign({ userId: user._id }, JWT_SECRET, { expiresIn: '2h' });
+
+    res.status(201).json({ token, userId: user._id });
   } catch (err) {
     res.status(500).json({ message: 'Sign up failed', error: err.message });
   }


### PR DESCRIPTION
## Summary
- return JWT token when users sign up instead of success message
- update signup handler to log user in after creation

## Testing
- `npm test` in `server` *(fails: no tests specified)*
- `npm test` in `client` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685a53a5f7b08329b97b9195a4043f31