### PR TITLE
Fix token variable usage in BooksSearch

### DIFF
--- a/client/src/components/BooksSearch.tsx
+++ b/client/src/components/BooksSearch.tsx
@@ -73,9 +73,9 @@ const BookSearch = () => {
 
       const response = await fetch('http://localhost:5000/api/books', {
         method: 'POST',
-        headers: { 
+        headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${'token'}`
+          'Authorization': `Bearer ${token}`
         },
         body: JSON.stringify(bookData),
       });


### PR DESCRIPTION
## Summary
- use actual `token` variable for authorization in `BooksSearch`

## Testing
- `npm test --silent`
- `npm test --prefix server --silent`

------
https://chatgpt.com/codex/tasks/task_e_685a53b7548c8329b543e31fb560cec9