### PR TITLE
Add Authorization header to book requests

### DIFF
--- a/client/src/pages/MyBooks.tsx
+++ b/client/src/pages/MyBooks.tsx
@@ -86,6 +86,9 @@ useEffect(() => {
     try {
         const res = await fetch(`http://localhost:5000/api/books/${id}`, {
           method: 'DELETE',
+          headers: {
+            'Authorization': `Bearer ${localStorage.getItem('token')}`
+          }
         });
         if (!res.ok) throw new Error('Failed to delete');
 

--- a/client/src/pages/Stats.tsx
+++ b/client/src/pages/Stats.tsx
@@ -27,7 +27,11 @@ const Stats = () => {
   const [books, setBooks] = useState<Book[]>([]);
 
   useEffect(() => {
-    fetch('http://localhost:5000/api/books')
+    fetch('http://localhost:5000/api/books', {
+      headers: {
+        'Authorization': `Bearer ${localStorage.getItem('token')}`
+      }
+    })
       .then((res) => res.json())
       .then((data) => setBooks(data))
       .catch((err) => console.error('Error fetching stats:', err));


### PR DESCRIPTION
## Summary
- include `Authorization` header when fetching book stats
- add same header to delete requests in My Books page

## Testing
- `npm run lint` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685a53bfda248329918a7ab3dcad1806