### PR TITLE
Fix login and signup token handling

### DIFF
--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -17,9 +17,8 @@ const Login = () => {
     try {
       const res = await fetch('http://localhost:5000/api/auth/login', {
         method: 'POST',
-        headers: { 
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${localStorage.getItem('token')}`
+        headers: {
+            'Content-Type': 'application/json'
         },
         body: JSON.stringify({ email, password })
       });

--- a/client/src/pages/Signup.tsx
+++ b/client/src/pages/Signup.tsx
@@ -15,9 +15,8 @@ const Signup = () => {
     try {
       const res = await fetch('http://localhost:5000/api/auth/signup', {
         method: 'POST',
-        headers: { 
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${localStorage.getItem('token')}`
+        headers: {
+            'Content-Type': 'application/json'
         },
         body: JSON.stringify({ email, password })
       });
@@ -25,8 +24,8 @@ const Signup = () => {
       const data = await res.json();
       if (!res.ok) throw new Error(data.message);
 
-      localStorage.setItem('token', data.token);
-      localStorage.setItem('userId', data.userId);
+      if (data.token) localStorage.setItem('token', data.token);
+      if (data.userId) localStorage.setItem('userId', data.userId);
       navigate('/books');
     } catch (err: any) {
       setError(err.message);


### PR DESCRIPTION
## Summary
- remove Authorization header from login and signup requests
- store auth token only when provided by the server

## Testing
- `npm run lint` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685a53c9518083299e0c1215df514154