### PR TITLE
Fix signup auth state

### DIFF
--- a/client/src/pages/Signup.tsx
+++ b/client/src/pages/Signup.tsx
@@ -26,9 +26,7 @@ const Signup = () => {
       const data = await res.json();
       if (!res.ok) throw new Error(data.message);
 
-      // merge conflict here. Review and fix later.
-      if (data.token) localStorage.setItem('token', data.token);
-      if (data.userId) localStorage.setItem('userId', data.userId);
+      login(data.userId, email, data.token);
 
       navigate('/books');
     } catch (err: any) {


### PR DESCRIPTION
## Summary
- remove leftover merge comment and update signup to call `login` after successful registration

## Testing
- `npx vitest run --silent` *(fails: Cannot find dependency 'jsdom')*
- `npm run lint --silent` *(fails: 3 errors, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_685a6363d6988329add5ba1de09532b4