### PR TITLE
Fix mismatched JWT payload

### DIFF
--- a/server/middleware/authMiddleware.js
+++ b/server/middleware/authMiddleware.js
@@ -9,7 +9,8 @@ const verifyToken = (req, res, next) => {
 
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
-    req.userId = decoded.id;
+    // Support tokens that store user ID under either "id" or "userId"
+    req.userId = decoded.userId || decoded.id;
     next();
   } catch (err) {
     res.status(401).json({ message: 'Invalid token' });

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -36,7 +36,7 @@ router.post('/login', async (req, res) => {
     const isMatch = await bcrypt.compare(password, user.password);
     if (!isMatch) return res.status(400).json({ message: 'Invalid credentials' });
 
-    const token = jwt.sign({ id: user._id }, JWT_SECRET, { expiresIn: '2h' });
+  const token = jwt.sign({ userId: user._id }, JWT_SECRET, { expiresIn: '2h' });
 
     res.status(200).json({ token, userId: user._id });
   } catch (err) {


### PR DESCRIPTION
## Summary
- ensure login tokens use the same `userId` field as signup tokens
- support both `id` and `userId` fields in auth middleware

## Testing
- `npx vitest run` *(fails: Need to install the following packages: vitest@3.2.4)*

------
https://chatgpt.com/codex/tasks/task_e_685a694e92288329a293882b48e409ed