### PR TITLE
Implement star rating input

### DIFF
--- a/client/src/components/BooksSearch.tsx
+++ b/client/src/components/BooksSearch.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import './BookSearch.css';
+import StarRating from './StarRating';
 
 interface BookItem {
   id: string;
@@ -135,15 +136,10 @@ const BookSearch = () => {
                     </label>
                     <label>
                         Rating:
-                        <input
-                            type="number"
-                            min="1"
-                            max="5"
+                        <StarRating
                             value={rating}
-                            onChange={(e) => {
-                                const value = e.target.value;
-                                setRating(value === '' ? '' : parseInt(value));
-                            }}
+                            onChange={(val) => setRating(val)}
+                            idPrefix={`search-${book.id}`}
                         />
                     </label>
                     <label>

--- a/client/src/components/StarRating.css
+++ b/client/src/components/StarRating.css
@@ -1,0 +1,26 @@
+.rating {
+  display: inline-block;
+}
+
+.rating input {
+  display: none;
+}
+
+.rating label {
+  float: right;
+  cursor: pointer;
+  color: #ccc;
+  transition: color 0.3s;
+}
+
+.rating label:before {
+  content: '\2605';
+  font-size: 30px;
+}
+
+.rating input:checked ~ label,
+.rating label:hover,
+.rating label:hover ~ label {
+  color: #6f00ff;
+  transition: color 0.3s;
+}

--- a/client/src/components/StarRating.tsx
+++ b/client/src/components/StarRating.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import './StarRating.css';
+
+interface StarRatingProps {
+  value: number | '';
+  onChange: (value: number) => void;
+  idPrefix?: string;
+}
+
+const StarRating: React.FC<StarRatingProps> = ({ value, onChange, idPrefix = 'rating' }) => {
+  const stars = [5, 4, 3, 2, 1];
+  return (
+    <div className="rating">
+      {stars.map((star) => (
+        <React.Fragment key={star}>
+          <input
+            type="radio"
+            id={`${idPrefix}-star${star}`}
+            name={idPrefix}
+            value={star}
+            checked={value === star}
+            onChange={() => onChange(star)}
+          />
+          <label htmlFor={`${idPrefix}-star${star}`}></label>
+        </React.Fragment>
+      ))}
+    </div>
+  );
+};
+
+export default StarRating;

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -29,8 +29,9 @@ const Login = () => {
       login(data.userId, email, data.token);
 
       navigate('/books'); // redirect after login
-    } catch (err: any) {
-      setError(err.message);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      setError(message);
     }
   };
 

--- a/client/src/pages/MyBooks.tsx
+++ b/client/src/pages/MyBooks.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import './MyBooks.css';
+import StarRating from '../components/StarRating';
 
 interface Book {
   _id: string;
@@ -124,15 +125,10 @@ useEffect(() => {
                 >
                     <label>
                     Rating:
-                    <input
-                        type="number"
-                        min="1"
-                        max="5"
+                    <StarRating
                         value={editRating}
-                        onChange={(e) => {
-                        const value = e.target.value;
-                        setEditRating(value === '' ? '' : parseInt(value));
-                        }}
+                        onChange={(val) => setEditRating(val)}
+                        idPrefix={`edit-${book._id}`}
                     />
                     </label>
                     <label>

--- a/client/src/pages/Signup.tsx
+++ b/client/src/pages/Signup.tsx
@@ -29,8 +29,9 @@ const Signup = () => {
       login(data.userId, email, data.token);
 
       navigate('/books');
-    } catch (err: any) {
-      setError(err.message);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      setError(message);
     }
   };
 


### PR DESCRIPTION
## Summary
- add a reusable `StarRating` component with accompanying styles
- swap numeric rating inputs in Add Book search results and My Books edit form for new star rating control
- fix lint errors in authentication pages

## Testing
- `npm --prefix client run lint`
- `npm --prefix client test` *(fails: Missing script)*
- `npm --prefix server test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685be679feb8832995397d8d15a8c6f7