### PR TITLE
Fix navbar media query width

### DIFF
--- a/client/src/components/Navbar.css
+++ b/client/src/components/Navbar.css
@@ -77,7 +77,7 @@
   color: #000;
 }
 
-@media (max-width) {
+@media (max-width: 600px) {
   .navbar {
     flex-direction: column;
     align-items: flex-start;


### PR DESCRIPTION
## Summary
- set actual width in `Navbar.css` media query to 600px

## Testing
- `npm run build` in `client`
- `npm run lint` in `client`


------
https://chatgpt.com/codex/tasks/task_e_685e535ae3608329b5ddbd57476144c5